### PR TITLE
Segregate compiler benchmarks into subfolders

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -43,5 +43,5 @@ jobs:
         comment-on-alert: true
         alert-threshold: 150%
         gh-pages-branch: gh-pages
-        benchmark-data-dir-path: 'benchmarks'
+        benchmark-data-dir-path: benchmarks/${{matrix.compiler}}
         auto-push: true


### PR DESCRIPTION
Publish benchmarks for each compiler into its own subfolder